### PR TITLE
Suppress invalid mdadm flag

### DIFF
--- a/salt/states/mdadm.py
+++ b/salt/states/mdadm.py
@@ -109,6 +109,8 @@ def present(name,
     elif next(six.itervalues(can_assemble)):
         do_assemble = True
         verb = 'assembled'
+        # "--chunk" is not a valid parameter to mdadm in assemble mode
+        kwargs.pop('chunk', None)
     else:
         do_assemble = False
         verb = 'created'


### PR DESCRIPTION
All kwargs are passed to raid.assemble, but '--chunks' is invalid in assembly mode.

### What does this PR do?
Drops "--chunk" as a keyword argument to raid.assemble
### What issues does this PR fix or reference?
#43517

### Previous Behavior
raid.assemble was invoked with `chunks` in `kwarg` if specified in the state configuration. This resulted in a failure to assemble an array

### New Behavior
chunk kwarg is removed if it's present and assembly rather than creation is requested.

### Tests written?
No
Manually checked that applying a `raid.present` state works when whether the underlying device is running, stopped, or gone (via raid.destroy).
